### PR TITLE
Fix/disallow multiple namespace

### DIFF
--- a/src/Pubsub.ts
+++ b/src/Pubsub.ts
@@ -2,7 +2,7 @@ let subscriber: any;
 
 export default new class PubSub {
     init (Subscriber: any) {
-        if (typeof Subscriber === undefined) {
+        if (typeof Subscriber === 'undefined') {
             throw new Error ('Please provide a new redis instance for subscribe')
         }
 
@@ -10,7 +10,7 @@ export default new class PubSub {
     }
 
     subscribe(channel: string) {
-        if (typeof subscriber.subscribe === undefined) {
+        if (typeof subscriber.subscribe === 'undefined') {
             throw new Error('The provided redis client doesn\'t supports subscribing to messages');
         }
 

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -24,21 +24,28 @@ export class Queue {
     constructor(opts: IQueueOpts) {
         this.opts = opts;
 
-        if (typeof this.opts.redis === undefined) {
+        if (typeof this.opts.redis === 'undefined') {
             throw new Error('Redis client not provided');
         }
 
-        if (typeof this.opts.subscriberRedis === undefined) {
-            throw new Error('Subscriber Redis Client Not provided');
+        if (typeof this.opts.subscriberRedis === 'undefined') {
+            throw new Error('Subscriber Redis Client not provided');
         }
 
         Pubsub.init(this.opts.subscriberRedis);
     }
 
     public registerNamespace(namespace: string, handler: (namespace:string, ctx: any) => any): any {
-        if (typeof namespace === undefined) {
+        if (this.namespace && this.namespace.length > 0) {
+            throw new Error('Cannot change namespace once initialized');
+        }
+
+        if (typeof namespace === 'undefined' || typeof namespace === null) {
             throw new Error('Namespace cannot be undefined or null');
         }
+
+
+
         this.namespace = namespace;
         this.registerPollingBooth(this.namespace, handler);
         return this;

--- a/test/index.js
+++ b/test/index.js
@@ -51,24 +51,21 @@ describe('JerryQuu', () => {
                 })
             });
         } catch (err) {
-            expect(err.message).to.equal('Subscriber Redis Client Not Provided');
+            expect(err.message).to.equal('Subscriber Redis Client not provided');
         }
     });
 
     it('throw an error if namespace not provided', () => {
-        try {
-            testEmailQueue.registerNamespace();
-        } catch (err) {
-            expect(err.message).to.equal('Namespace cannot be undefined or null');
-        }
+        expect(() => testEmailQueue.registerNamespace()).to.throw('Namespace cannot be undefined or null');
     });
 
     it('throws an error if an empty message is pushed', () => {
-        try {
-            testEmailQueue.pushMessage();
-        } catch (err) {
-            expect(err.message).to.equal('Message cannot be undefined or empty');
-        }
+        expect(() => testEmailQueue.pushMessage()).to.throw('Message cannot be undefined or empty');
+    });
+
+    it('throw an error if multiple namespace are tried to be registered for one instance', () => {
+        testEmailQueue.registerNamespace('mytestqueue');
+        expect(() => testEmailQueue.registerNamespace(null)).to.throw('Cannot change namespace once initialized')
     });
 
     it('can push a message', () => {


### PR DESCRIPTION
Disallows multiple namespaces to be registered once a queue instance is initialized. Since namespaces allows us to segregate messages in their separate spaces in the redis db. It is not a good idea to allow overriding the existing namespace for a instance.